### PR TITLE
Add pricing sheet link to navigation

### DIFF
--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -23,6 +23,7 @@ import {
   Crown,
   Zap,
   Target,
+  Calculator,
 } from "lucide-react"
 import Link from "next/link"
 
@@ -199,6 +200,17 @@ export function Sidebar({ modules, userProgress }: SidebarProps) {
                   Configurações
                 </Button>
               </Link>
+              <a 
+                href="https://como-precificar-seus-ser-67axihe.gamma.site/" 
+                target="_blank" 
+                rel="noopener noreferrer"
+                onClick={() => setIsOpen(false)}
+              >
+                <Button variant="ghost" className="w-full justify-start text-gray-300 hover:text-white hover:bg-gray-800/50">
+                  <Calculator className="h-4 w-4 mr-2" />
+                  Planilha de Precificação
+                </Button>
+              </a>
             </div>
           </div>
 


### PR DESCRIPTION
Adiciona um novo item "Planilha de Precificação" na navegação lateral para direcionar a um link externo.

---
<a href="https://cursor.com/background-agent?bcId=bc-8b500523-0fe3-4b4e-9c95-c7b5a6562f0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8b500523-0fe3-4b4e-9c95-c7b5a6562f0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

